### PR TITLE
Add byClassName function

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ var result = findParent.byMatcher(element, function(node) {
 // result is === to the element <div class="foo">
 ```
 
+### byClassName(element, className)
+
+```
+var findParent = require('find-parent');
+
+var element = document.getElementsByTagName('a')[0];
+
+var result = findParent.byClassName(element, 'foo');
+
+// result is === to the element <div class="foo">
+```

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var FindParent = {
   byMatcher: function(element, func) {
-    if (!element) {
+    if (!element || element === document) {
       return undefined;
     }
 
@@ -11,6 +11,12 @@ var FindParent = {
     }
 
     return this.byMatcher(element.parentNode, func);
+  },
+
+  byClassName: function(element, className) {
+    return this.byMatcher(element, function(el) {
+      return el.classList.contains(className);
+    });
   }
 };
 

--- a/test/src-tests/index-test.js
+++ b/test/src-tests/index-test.js
@@ -5,6 +5,7 @@ var findParent = require('../../');
 
 describe('find-parent/index', function() {
   var fixtureDiv;
+  var element;
 
   before(function() {
     fixtureDiv = document.createElement('div');
@@ -15,9 +16,9 @@ describe('find-parent/index', function() {
 
   beforeEach(function() {
     var source = '\
-    <div class="foo">\
-      <span id="test">\
-        <a href="http://google.com">link text</a>\
+    <div class="ancestor">\
+      <span id="test" class="parent">\
+        <a href="http://google.com" class="itself">link text</a>\
       </span>\
     </div>';
 
@@ -25,44 +26,122 @@ describe('find-parent/index', function() {
   });
 
   describe('#byMatcher', function() {
-    it('should return undefined when no parent matches', function() {
-      var element = document.getElementsByTagName('a')[0];
+    describe('with an element outside of the document', function() {
+      var ancestor;
+      var parent;
 
-      var result = findParent.byMatcher(element, function() {
-        return false;
+      beforeEach(function() {
+        ancestor = document.createElement('div');
+        parent = document.createElement('span');
+        element = document.createElement('a');
+        parent.appendChild(element);
+        ancestor.appendChild(parent);
       });
+
+      it('should return undefined when no parent matches', function() {
+        var result = findParent.byMatcher(element, function() {
+          return false;
+        });
+
+        assert.isUndefined(result);
+      });
+
+      it('should return itself when it matches', function() {
+        var result = findParent.byMatcher(element, function() {
+          return true;
+        });
+
+        assert.equal(result, element);
+      });
+
+      it('should find direct parent', function() {
+        var result = findParent.byMatcher(element, function(node) {
+          return node.tagName === parent.tagName;
+        });
+
+        assert.equal(result, parent);
+      });
+
+      it('should find ancestor', function() {
+        var result = findParent.byMatcher(element, function(node) {
+          return node.tagName === ancestor.tagName;
+        });
+
+        assert.equal(result, ancestor);
+      });
+    });
+
+    describe('with an element in the document', function() {
+      beforeEach(function() {
+        element = document.getElementsByTagName('a')[0];
+      });
+
+      it('should never pass matcher the document object', function() {
+        var result = findParent.byMatcher(element, function() {
+          assert.notEqual(element, document);
+          return false;
+        });
+
+        assert.isUndefined(result);
+      });
+
+      it('should return undefined when no parent matches', function() {
+        var result = findParent.byMatcher(element, function() {
+          return false;
+        });
+
+        assert.isUndefined(result);
+      });
+
+      it('should return itself when it matches', function() {
+        var result = findParent.byMatcher(element, function() {
+          return true;
+        });
+
+        assert.equal(result, element);
+      });
+
+      it('should find direct parent', function() {
+        var result = findParent.byMatcher(element, function(node) {
+          return node.id === 'test';
+        });
+
+        assert.equal(result.id, 'test');
+      });
+
+      it('should find ancestor', function() {
+        var result = findParent.byMatcher(element, function(node) {
+          return node.className === 'ancestor';
+        });
+
+        assert.equal(result.className, 'ancestor');
+      });
+    });
+  });
+
+  describe('#byClassName', function() {
+    it('should return undefined if there are no ancestors with className', function() {
+      var result = findParent.byClassName(element, 'nonexistant');
 
       assert.isUndefined(result);
     });
 
-    it('should return itself when it matches', function() {
-      var element = document.getElementsByTagName('a')[0];
+    it('should return itself when it has className', function() {
+      var result = findParent.byClassName(element, 'itself');
 
-      var result = findParent.byMatcher(element, function() {
-        return true;
-      });
-
-      assert.equal(element, result);
+      assert.equal(result, element);
     });
 
-    it('should find direct parent', function() {
-      var element = document.getElementsByTagName('a')[0];
+    it('should return parent with className', function() {
+      var result = findParent.byClassName(element, 'parent');
 
-      var result = findParent.byMatcher(element, function(node) {
-        return node.id === 'test';
-      });
-
-      assert.equal('test', result.id);
+      assert.equal(result.className, 'parent');
     });
 
-    it('should find ancestor', function() {
-      var element = document.getElementsByTagName('a')[0];
+    it('should return ancestor with className', function() {
+      var result = findParent.byClassName(element, 'ancestor');
 
-      var result = findParent.byMatcher(element, function(node) {
-        return node.className === 'foo';
-      });
-
-      assert.equal('foo', result.className);
+      assert.equal(result.className, 'ancestor');
     });
   });
 });


### PR DESCRIPTION
Add method to find parent by className
Add guard against sending document to match function (since document doesn't have attributes)
Add tests to verify byMatcher operates on elements that are not appended to document
Correct argument order of testing methods to (actual, expected)
