### PR TITLE
remove chai dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var assert = require('chai').assert;
-
 var FindParent = {
   byMatcher: function(element, func, opts) {
     if (opts === undefined) {
       opts = {};
     }
 
-    assert.isObject(opts);
+    if (opts === null || Array.isArray(opts) || typeof opts !== 'object') {
+      throw new Error('Expected opts to be an object.');
+    }
 
     if (!element || element === document) {
       if (opts.throwOnMiss) {


### PR DESCRIPTION
There is no need for the chai dependency to be able to check if opts is an object.
